### PR TITLE
Update to UniversalDashboard.Knob.psm1

### DIFF
--- a/src/UniversalDashboard.Knob.psm1
+++ b/src/UniversalDashboard.Knob.psm1
@@ -77,7 +77,7 @@ function New-UDKnob {
             font = $font 
             fontWeight = $FontWeight
             clockwise = -Not $Counterclockwise.IsPresent
-            angleArch =$AngleArc
+            angleArc =$AngleArc
             angleOffset = $AngleOffset 
             title = $Title
         }


### PR DESCRIPTION
Fixing AngleArc option, -AngleArc does not work when using New-UDKnob, line 80 of the .psm1 file read "angleArch =$AngleArc" but there is no "angleArch" property in the .js correcting it to read:

angleArc =$AngleArc